### PR TITLE
Small fixes and update to Buildkite Agent 3.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 PORTNAME=	buildkite-agent
 DISTVERSIONPREFIX=	v
-DISTVERSION=	3.2.0
+DISTVERSION=	3.16.0
 CATEGORIES=	devel sysutils
 
 MAINTAINER=	dch@FreeBSD.org
@@ -17,7 +17,7 @@ BUILD_DEPENDS=	go>=1.9:lang/go
 USE_GITHUB=	yes
 GH_ACCOUNT=	buildkite
 GH_PROJECT=	agent
-#GH_TAGNAME=	v3.2.0
+#GH_TAGNAME=	v3.16.0
 
 USES=		go
 GO_PKGNAME=	github.com/${GH_ACCOUNT}/${GH_PROJECT}

--- a/distinfo
+++ b/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1527577196
-SHA256 (buildkite-agent-v3.2.0_GH0.tar.gz) = e09665230ed9466a3f5458d9d5762e01b172595b6fa35a5059ad21f750d1db06
-SIZE (buildkite-agent-v3.2.0_GH0.tar.gz) = 4737321
+TIMESTAMP = 1574418469
+SHA256 (buildkite-agent-v3.16.0_GH0.tar.gz) = aa489b37a4f68403a6f7a6c2801ee28412ced55932396998c92b953f29555e1e
+SIZE (buildkite-agent-v3.16.0_GH0.tar.gz) = 6025612

--- a/files/buildkite.in
+++ b/files/buildkite.in
@@ -34,11 +34,13 @@ load_rc_config $name
 : ${buildkite_options=""}
 : ${buildkite_vars=""}
 
+sig_stop="INT"
+
 pidfile=/var/run/buildkite.pid
 command=/usr/sbin/daemon
 command_args="-t ${name} \
     -u ${buildkite_account} \
-    -r -P ${pidfile} \
+    -P ${pidfile} \
     -o ${buildkite_logfile} \
     /usr/bin/env ${buildkite_vars} \
       HOME=`pw usershow ${buildkite_account} | cut -d: -f9` \
@@ -49,5 +51,23 @@ command_args="-t ${name} \
       ${buildkite_options}"
 
 required_files="${buildkite_config}"
+
+_run_rc_killcmd()
+{
+    local _cmd
+    local _pid
+
+    # Terminate buildkite-agent by sending SIGINT to the child process to
+    # ensure it unregisters and disconnects, otherwise the agent will still
+    # be listed under the Agents tab.
+    _pid=$(pgrep -P ${rc_pid})
+    if [ -n "$_pid" ]; then
+        _cmd="kill -$1 $_pid"
+        if [ -n "$_user" ]; then
+            _cmd="su -m ${_user} -c 'sh -c \"${_cmd}\"'"
+        fi
+    fi
+    echo "$_cmd"
+}
 
 run_rc_command "$1"

--- a/files/buildkite.in
+++ b/files/buildkite.in
@@ -29,7 +29,7 @@ load_rc_config $name
 : ${buildkite_enable=NO}
 : ${buildkite_logfile:=/var/log/buildkite.log}
 : ${buildkite_account:=nobody}
-: ${buildkite_config:="%%ETCDIR%%/buildkite-agent.cfg"}
+: ${buildkite_config:="/usr/local/etc/buildkite/buildkite-agent.cfg"}
 : ${buildkite_flags=""}
 : ${buildkite_options=""}
 : ${buildkite_vars=""}
@@ -39,12 +39,14 @@ command=/usr/sbin/daemon
 command_args="-t ${name} \
     -u ${buildkite_account} \
     -r -P ${pidfile} \
+    -o ${buildkite_logfile} \
     /usr/bin/env ${buildkite_vars} \
       HOME=`pw usershow ${buildkite_account} | cut -d: -f9` \
       BUILDKITE_AGENT_TOKEN=${buildkite_token} \
     /usr/local/bin/buildkite-agent start \
-    --config ${buildkite_config} \
-    ${buildkite_options}"
+      --config ${buildkite_config} \
+      --no-color \
+      ${buildkite_options}"
 
 required_files="${buildkite_config}"
 

--- a/files/pkg-message.in
+++ b/files/pkg-message.in
@@ -10,7 +10,7 @@ itself may launch.
 
 Note: the supplied user must have full filesystems permissions over its homedir.
 
-# %%PREFIX%%/rc.conf.d/buildkite
+# %%PREFIX%%/etc/rc.conf.d/buildkite
 # mandatory parameters
 buildkite_enable=YES
 buildkite_token=abc123456def

--- a/pkg-plist
+++ b/pkg-plist
@@ -2,13 +2,13 @@ bin/buildkite-agent
 @dir %%ETCDIR%%/hooks
 @dir %%ETCDIR%%/plugins
 @sample %%ETCDIR%%/buildkite-agent.cfg.sample
-%%PORTEXAMPLES%%%%EXAMPLESDIR%%/hooks/checkout.sample
-%%PORTEXAMPLES%%%%EXAMPLESDIR%%/hooks/command.sample
-%%PORTEXAMPLES%%%%EXAMPLESDIR%%/hooks/environment.sample
-%%PORTEXAMPLES%%%%EXAMPLESDIR%%/hooks/post-artifact.sample
-%%PORTEXAMPLES%%%%EXAMPLESDIR%%/hooks/post-checkout.sample
-%%PORTEXAMPLES%%%%EXAMPLESDIR%%/hooks/post-command.sample
-%%PORTEXAMPLES%%%%EXAMPLESDIR%%/hooks/pre-artifact.sample
-%%PORTEXAMPLES%%%%EXAMPLESDIR%%/hooks/pre-checkout.sample
-%%PORTEXAMPLES%%%%EXAMPLESDIR%%/hooks/pre-command.sample
-%%PORTEXAMPLES%%%%EXAMPLESDIR%%/hooks/pre-exit.sample
+%%EXAMPLESDIR%%/hooks/checkout.sample
+%%EXAMPLESDIR%%/hooks/command.sample
+%%EXAMPLESDIR%%/hooks/environment.sample
+%%EXAMPLESDIR%%/hooks/post-artifact.sample
+%%EXAMPLESDIR%%/hooks/post-checkout.sample
+%%EXAMPLESDIR%%/hooks/post-command.sample
+%%EXAMPLESDIR%%/hooks/pre-artifact.sample
+%%EXAMPLESDIR%%/hooks/pre-checkout.sample
+%%EXAMPLESDIR%%/hooks/pre-command.sample
+%%EXAMPLESDIR%%/hooks/pre-exit.sample


### PR DESCRIPTION
This PR updates the port to Buildkite Agent 3.16 and contains some small fixes. The most important fix is the update to buildkite-agent process termination. The function `_run_rc_killcmd` is overridden to kill the actual buildkite-agent process with `SIGINT` so that the agent disconnects from the Buildkite service.

Please consider pulling these changes.